### PR TITLE
Pet application continued SB

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,21 @@ class ApplicationController < ActionController::Base
   def favorite
     @favorite ||= Favorite.new(session[:favorite])
   end
+
+  def toggle_approval_status(pet_application)
+    if pet_application[:approval_status] == "unapproved"
+      "approved"
+    else
+      "unapproved"
+    end
+  end
+
+  def toggle_adoption_status(pet)
+    if pet.adoption_status == "adoptable"
+      "adoption pending"
+    else
+      "adoptable"
+    end
+  end
+
 end

--- a/app/controllers/pet_applications_controller.rb
+++ b/app/controllers/pet_applications_controller.rb
@@ -1,6 +1,8 @@
 class PetApplicationsController < ApplicationController
+
   def index
     @pet = Pet.find(params[:pet_id])
     @applicants = @pet.adoption_applications
   end
+ll
 end

--- a/app/controllers/pet_applications_controller.rb
+++ b/app/controllers/pet_applications_controller.rb
@@ -7,18 +7,17 @@ class PetApplicationsController < ApplicationController
 
   def update
     pet = Pet.find(params[:pet_id])
-    pet.update({adoption_status: "adoption pending"})
-    app_id = params[:application_id]
-    application = AdoptionApplication.find(app_id)
-    application.update({approval_status: toggle_approval_status(application)})
-    redirect_to "/pets/#{pet.id}?application_id=#{app_id}"
+    pet.update({adoption_status: toggle_adoption_status(pet)})
+    pet_application = PetApplication.where(adoption_application_id: params[:application_id], pet_id: pet.id).first
+    pet_application.update({approval_status: toggle_approval_status(pet_application)})
+    redirect_approval_status(pet_application)
   end
 
-  def toggle_approval_status(application)
-    if application.approval_status == "unapproved"
-      "approved"
+  def redirect_approval_status(pet_application)
+    if pet_application[:approval_status] == "approved"
+      redirect_to "/pets/#{pet_application.pet_id}?application_id=#{pet_application[:adoption_application_id]}"
     else
-      "unapproved"
+      redirect_to "/adoption_applications/#{pet_application[:adoption_application_id]}"
     end
   end
 

--- a/app/controllers/pet_applications_controller.rb
+++ b/app/controllers/pet_applications_controller.rb
@@ -4,5 +4,11 @@ class PetApplicationsController < ApplicationController
     @pet = Pet.find(params[:pet_id])
     @applicants = @pet.adoption_applications
   end
-ll
+
+  def update
+    pet = Pet.find(params[:pet_id])
+    app_id = params[:application_id]
+    pet.update({adoption_status: "adoption pending"})
+    redirect_to "/pets/#{pet.id}?application_id=#{app_id}"
+  end
 end

--- a/app/controllers/pet_applications_controller.rb
+++ b/app/controllers/pet_applications_controller.rb
@@ -7,8 +7,19 @@ class PetApplicationsController < ApplicationController
 
   def update
     pet = Pet.find(params[:pet_id])
-    app_id = params[:application_id]
     pet.update({adoption_status: "adoption pending"})
+    app_id = params[:application_id]
+    application = AdoptionApplication.find(app_id)
+    application.update({approval_status: toggle_approval_status(application)})
     redirect_to "/pets/#{pet.id}?application_id=#{app_id}"
   end
+
+  def toggle_approval_status(application)
+    if application.approval_status == "unapproved"
+      "approved"
+    else
+      "unapproved"
+    end
+  end
+
 end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -9,6 +9,9 @@ class PetsController < ApplicationController
 
   def show
     @pet = Pet.find(params[:id])
+    if !params[:application_id].nil?
+      @applicant = AdoptionApplication.find(params[:application_id])
+    end
   end
 
   def create

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -36,16 +36,19 @@ class PetsController < ApplicationController
 
   def adopt_update
     pet = Pet.find(params[:id])
-    if pet.adoption_status == "adoptable"
-      pet.adoption_status = "adoption pending"
-    elsif pet.adoption_status == "adoption pending"
-      pet.adoption_status = "adoptable"
-    end
-    pet.update({adoption_status: pet.adoption_status})
+    pet.update({adoption_status: toggle_adoption_status(pet)})
     redirect_to "/pets/#{pet.id}"
   end
 
   private
+
+  def toggle_adoption_status(pet)
+    if pet.adoption_status == "adoptable"
+      "adoption pending"
+    else
+      "adoptable"
+    end
+  end
 
   def pet_params
     params.permit(:image, :name, :description, :approximate_age, :sex, :shelter_id)

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -41,7 +41,7 @@ class PetsController < ApplicationController
   end
 
   private
-
+  
   def pet_params
     params.permit(:image, :name, :description, :approximate_age, :sex, :shelter_id)
   end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -42,14 +42,6 @@ class PetsController < ApplicationController
 
   private
 
-  def toggle_adoption_status(pet)
-    if pet.adoption_status == "adoptable"
-      "adoption pending"
-    else
-      "adoptable"
-    end
-  end
-
   def pet_params
     params.permit(:image, :name, :description, :approximate_age, :sex, :shelter_id)
   end

--- a/app/models/adoption_application.rb
+++ b/app/models/adoption_application.rb
@@ -12,4 +12,9 @@ class AdoptionApplication < ApplicationRecord
     end
     pets.uniq
   end
+
+  def approval_status(pet, application)
+      pet_application = PetApplication.where(adoption_application_id: application.id, pet_id: pet.id).last
+      pet_application[:approval_status]
+  end
 end

--- a/app/views/adoption_application/show.html.erb
+++ b/app/views/adoption_application/show.html.erb
@@ -15,8 +15,8 @@
     <%= link_to "#{pet.name}", "/pets/#{pet.id}" %>
     <% if pet.adoption_status == "adoptable" %>
       <%= link_to "Approve Application", "/pets/#{pet.id}/applications/#{@application.id}", method: :patch %>
-    <% elsif @application.approval_status == "approved" %>
-      <%= link_to "Unapprove Application", "/adoption_applications/update", method: :patch %> <
+    <% elsif @application.approval_status(pet, @application) == "approved" %>
+      <%= link_to "Unapprove Application", "/pets/#{pet.id}/applications/#{@application.id}", method: :patch %>
     <% end %>
   <br></br>
   </section>

--- a/app/views/adoption_application/show.html.erb
+++ b/app/views/adoption_application/show.html.erb
@@ -15,6 +15,8 @@
     <%= link_to "#{pet.name}", "/pets/#{pet.id}" %>
     <% if pet.adoption_status == "adoptable" %>
       <%= link_to "Approve Application", "/pets/#{pet.id}/applications/#{@application.id}", method: :patch %>
+    <% elsif @application.approval_status == "approved" %>
+      <%= link_to "Unapprove Application", "/adoption_applications/update", method: :patch %> <
     <% end %>
   <br></br>
   </section>

--- a/app/views/adoption_application/show.html.erb
+++ b/app/views/adoption_application/show.html.erb
@@ -13,7 +13,7 @@
 <% @application.pets.each do |pet| %>
   <section class="pets-<%= pet.id %>">
     <%= link_to "#{pet.name}", "/pets/#{pet.id}" %>
-    <%= link_to "Approve Application", "/pets/#{pet.id}/applications/#{@application.id}", method: :patch %>
+    <%= link_to "Approve Application", "/pets/#{pet.id}/adopt", method: :patch %>
   <br></br>
   </section>
 <% end %>

--- a/app/views/adoption_application/show.html.erb
+++ b/app/views/adoption_application/show.html.erb
@@ -13,7 +13,9 @@
 <% @application.pets.each do |pet| %>
   <section class="pets-<%= pet.id %>">
     <%= link_to "#{pet.name}", "/pets/#{pet.id}" %>
-    <%= link_to "Approve Application", "/pets/#{pet.id}/applications/#{@application.id}", method: :patch %>
+    <% if pet.adoption_status == "adoptable" %>
+      <%= link_to "Approve Application", "/pets/#{pet.id}/applications/#{@application.id}", method: :patch %>
+    <% end %>
   <br></br>
   </section>
 <% end %>

--- a/app/views/adoption_application/show.html.erb
+++ b/app/views/adoption_application/show.html.erb
@@ -13,7 +13,7 @@
 <% @application.pets.each do |pet| %>
   <section class="pets-<%= pet.id %>">
     <%= link_to "#{pet.name}", "/pets/#{pet.id}" %>
-    <%= link_to "Approve Application", "/pets/#{pet.id}/adopt", method: :patch %>
+    <%= link_to "Approve Application", "/pets/#{pet.id}/applications/#{@application.id}", method: :patch %>
   <br></br>
   </section>
 <% end %>

--- a/app/views/adoption_application/show.html.erb
+++ b/app/views/adoption_application/show.html.erb
@@ -1,14 +1,19 @@
 <h3>Application: </h3>
 <section class="index">
-<p><%= "Name: #{@application.name}" %></p>
-<p><%= "Address: #{@application.address}" %></p>
-<p><%= "City: #{@application.city}" %></p>
-<p><%= "State: #{@application.state}" %></p>
-<p><%= "Zip Code: #{@application.zip}" %></p>
-<p><%= "Phone Number: #{@application.phone_number}" %></p>
-<p><%= "Description: #{@application.description}" %></p>
+  <p><%= "Name: #{@application.name}" %></p>
+  <p><%= "Address: #{@application.address}" %></p>
+  <p><%= "City: #{@application.city}" %></p>
+  <p><%= "State: #{@application.state}" %></p>
+  <p><%= "Zip Code: #{@application.zip}" %></p>
+  <p><%= "Phone Number: #{@application.phone_number}" %></p>
+  <p><%= "Description: #{@application.description}" %></p>\
+</section>
+
 <h2>Pets Applied For: </h2>
 <% @application.pets.each do |pet| %>
-  <%= link_to "#{pet.name}", "/pets/#{pet.id}" %>
+  <section class="pets-<%= pet.id %>">
+    <%= link_to "#{pet.name}", "/pets/#{pet.id}" %>
+    <%= link_to "Approve Application", "/pets/#{pet.id}/applications/#{@application.id}", method: :patch %>
   <br></br>
+  </section>
 <% end %>

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -5,6 +5,10 @@
 <p><%= "Age: #{@pet.approximate_age}" %></p>
 <p><%= "Sex: #{@pet.sex}" %></p>
 <p><%= "Adoption Status: #{@pet.adoption_status}" %></p>
+<% if !@applicant.nil? %>
+  <p><%= "This pet is on hold for #{@applicant.name}." %></p>
+<% end %>
+
 <div class="links">
 
 <% if favorite.favorite_status(@pet.id) == true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,4 +32,6 @@ Rails.application.routes.draw do
   get '/adoption_applications/new', to: 'adoption_application#new'
   post '/favorites', to: 'adoption_application#create'
   get '/adoption_applications/:application_id', to: 'adoption_application#show'
+  get '/pets/:pet_id/applications', to: 'pet_applications#index'
+  patch '/pets/:pet_id/applications/:application_id', to: 'pet_applications#update'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,4 @@ Rails.application.routes.draw do
   get '/adoption_applications/new', to: 'adoption_application#new'
   post '/favorites', to: 'adoption_application#create'
   get '/adoption_applications/:application_id', to: 'adoption_application#show'
-  get '/pets/:pet_id/applications', to: 'pet_applications#index'
-  patch '/pets/:pet_id/applications/:application_id', to: 'pet_applications#update'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,4 +33,5 @@ Rails.application.routes.draw do
   post '/favorites', to: 'adoption_application#create'
   get '/adoption_applications/:application_id', to: 'adoption_application#show'
   get '/pets/:pet_id/applications', to: 'pet_applications#index'
+  patch '/pets/:pet_id/applications/:application_id', to: 'pet_applications#update'
 end

--- a/db/migrate/20200519211854_add_approval_status_to_adoption_application.rb
+++ b/db/migrate/20200519211854_add_approval_status_to_adoption_application.rb
@@ -1,0 +1,5 @@
+class AddApprovalStatusToAdoptionApplication < ActiveRecord::Migration[5.1]
+  def change
+    add_column :adoption_applications, :approval_status, :string, default: "unapproved"
+  end
+end

--- a/db/migrate/20200519211854_add_approval_status_to_adoption_application.rb
+++ b/db/migrate/20200519211854_add_approval_status_to_adoption_application.rb
@@ -1,5 +1,0 @@
-class AddApprovalStatusToAdoptionApplication < ActiveRecord::Migration[5.1]
-  def change
-    add_column :adoption_applications, :approval_status, :string, default: "unapproved"
-  end
-end

--- a/db/migrate/20200519224539_add_approval_status_to_pet_applications.rb
+++ b/db/migrate/20200519224539_add_approval_status_to_pet_applications.rb
@@ -1,0 +1,5 @@
+class AddApprovalStatusToPetApplications < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pet_applications, :approval_status, :string, default: "unapproved"
+  end
+end

--- a/db/migrate/20200520003008_remove_approval_status_from_adoption_applications.rb
+++ b/db/migrate/20200520003008_remove_approval_status_from_adoption_applications.rb
@@ -1,0 +1,5 @@
+class RemoveApprovalStatusFromAdoptionApplications < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :adoption_applications, :approval_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200519224539) do
+ActiveRecord::Schema.define(version: 20200520003008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,7 +23,6 @@ ActiveRecord::Schema.define(version: 20200519224539) do
     t.string "zip"
     t.string "phone_number"
     t.string "description"
-    t.string "approval_status", default: "unapproved"
   end
 
   create_table "pet_applications", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200519211854) do
+ActiveRecord::Schema.define(version: 20200519224539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 20200519211854) do
   create_table "pet_applications", force: :cascade do |t|
     t.bigint "pet_id"
     t.bigint "adoption_application_id"
+    t.string "approval_status", default: "unapproved"
     t.index ["adoption_application_id"], name: "index_pet_applications_on_adoption_application_id"
     t.index ["pet_id"], name: "index_pet_applications_on_pet_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200517014946) do
+ActiveRecord::Schema.define(version: 20200519211854) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20200517014946) do
     t.string "zip"
     t.string "phone_number"
     t.string "description"
+    t.string "approval_status", default: "unapproved"
   end
 
   create_table "pet_applications", force: :cascade do |t|

--- a/spec/features/adoption_application/show_spec.rb
+++ b/spec/features/adoption_application/show_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "applications show page" do
     application = AdoptionApplication.create(name: "Stella", address: "street", city: "City", state: "ST", zip: "34567", phone_number: "545-567-7643", description: "I'm awesome")
 
     PetApplication.create(pet_id: pet_1.id, adoption_application_id: application.id)
-    PetApplication.create(pet_id: pet_2.id, adoption_application_id: application_1.id)
+    PetApplication.create(pet_id: pet_2.id, adoption_application_id: application.id)
 
     visit "/adoption_applications/#{application.id}"
 

--- a/spec/features/adoption_application/show_spec.rb
+++ b/spec/features/adoption_application/show_spec.rb
@@ -24,4 +24,26 @@ RSpec.describe "applications show page" do
 
     expect(current_path).to eq("/pets/#{pet_1.id}")
   end
+
+  it "can link to approve application" do
+    shelter = Shelter.create(name: "Happy Puppies", address: "55 Street St", city: "Danger Mountain", state: "UT", zip: "80304")
+
+    pet_1 = Pet.create(image: "image.jpeg", name: "Kunga", approximate_age: "1", sex: "male", shelter_id: shelter.id)
+    pet_2 = Pet.create(image: "image.jpeg", name: "Honey Pie", approximate_age: "11", sex: "female", shelter_id: shelter.id)
+
+    application = AdoptionApplication.create(name: "Stella", address: "street", city: "City", state: "ST", zip: "34567", phone_number: "545-567-7643", description: "I'm awesome")
+
+    PetApplication.create(pet_id: pet_1.id, adoption_application_id: application.id)
+    PetApplication.create(pet_id: pet_2.id, adoption_application_id: application_1.id)
+
+    visit "/adoption_applications/#{application.id}"
+
+    within ".pets-#{pet_1.id}" do
+      click_link "Approve Application"
+    end
+
+    expect(current_path).to eq("/pets/#{pet_1.id}")
+    expect(page).to have_content("pending")
+    expect(page).to have_content("This pet is on hold for Stella.")
+  end
 end

--- a/spec/features/adoption_application/show_spec.rb
+++ b/spec/features/adoption_application/show_spec.rb
@@ -46,4 +46,60 @@ RSpec.describe "applications show page" do
     expect(page).to have_content("adoption pending")
     expect(page).to have_content("This pet is on hold for Stella.")
   end
+
+  it "can approve application for multiple pets" do
+    shelter = Shelter.create(name: "Happy Puppies", address: "55 Street St", city: "Danger Mountain", state: "UT", zip: "80304")
+
+    pet_1 = Pet.create(image: "image.jpeg", name: "Kunga", approximate_age: "1", sex: "male", shelter_id: shelter.id)
+    pet_2 = Pet.create(image: "image.jpeg", name: "Honey Pie", approximate_age: "11", sex: "female", shelter_id: shelter.id)
+
+    application = AdoptionApplication.create(name: "Stella", address: "street", city: "City", state: "ST", zip: "34567", phone_number: "545-567-7643", description: "I'm awesome")
+
+    PetApplication.create(pet_id: pet_1.id, adoption_application_id: application.id)
+    PetApplication.create(pet_id: pet_2.id, adoption_application_id: application.id)
+
+    visit "/adoption_applications/#{application.id}"
+
+    within ".pets-#{pet_1.id}" do
+      click_link "Approve Application"
+    end
+
+    expect(current_path).to eq("/pets/#{pet_1.id}")
+    expect(page).to have_content("adoption pending")
+    expect(page).to have_content("This pet is on hold for Stella.")
+
+    visit "/adoption_applications/#{application.id}"
+
+    within ".pets-#{pet_2.id}" do
+      click_link "Approve Application"
+    end
+
+    expect(current_path).to eq("/pets/#{pet_2.id}")
+    expect(page).to have_content("adoption pending")
+    expect(page).to have_content("This pet is on hold for Stella.")
+  end
+
+  it "approve application link can be removed once application for specific pet has been approved" do
+    shelter = Shelter.create(name: "Happy Puppies", address: "55 Street St", city: "Danger Mountain", state: "UT", zip: "80304")
+
+    pet_1 = Pet.create(image: "image.jpeg", name: "Kunga", approximate_age: "1", sex: "male", shelter_id: shelter.id)
+    pet_2 = Pet.create(image: "image.jpeg", name: "Honey Pie", approximate_age: "11", sex: "female", shelter_id: shelter.id)
+
+    application = AdoptionApplication.create(name: "Stella", address: "street", city: "City", state: "ST", zip: "34567", phone_number: "545-567-7643", description: "I'm awesome")
+    application2 = AdoptionApplication.create(name: "Betsy", address: "street", city: "City", state: "ST", zip: "34567", phone_number: "545-567-7643", description: "I'm awesome as well")
+
+    PetApplication.create(pet_id: pet_1.id, adoption_application_id: application.id)
+    PetApplication.create(pet_id: pet_1.id, adoption_application_id: application2.id)
+
+    visit "/adoption_applications/#{application.id}"
+
+    within ".pets-#{pet_1.id}" do
+      click_link "Approve Application"
+    end
+
+    visit "/adoption_applications/#{application2.id}"
+
+    expect(page).to have_no_content("Approve Application")
+
+  end
 end

--- a/spec/features/adoption_application/show_spec.rb
+++ b/spec/features/adoption_application/show_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "applications show page" do
     expect(page).to have_no_content("Approve Application")
   end
 
-  xit "can update pet adoption status with unapprove button" do
+  it "can update pet adoption status with unapprove button" do
     shelter = Shelter.create(name: "Happy Puppies", address: "55 Street St", city: "Danger Mountain", state: "UT", zip: "80304")
 
     pet_1 = Pet.create(image: "image.jpeg", name: "Kunga", approximate_age: "1", sex: "male", shelter_id: shelter.id)

--- a/spec/features/adoption_application/show_spec.rb
+++ b/spec/features/adoption_application/show_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "applications show page" do
     end
 
     expect(current_path).to eq("/pets/#{pet_1.id}")
-    expect(page).to have_content("pending")
+    expect(page).to have_content("adoption pending")
     expect(page).to have_content("This pet is on hold for Stella.")
   end
 end

--- a/spec/features/adoption_application/show_spec.rb
+++ b/spec/features/adoption_application/show_spec.rb
@@ -83,7 +83,6 @@ RSpec.describe "applications show page" do
     shelter = Shelter.create(name: "Happy Puppies", address: "55 Street St", city: "Danger Mountain", state: "UT", zip: "80304")
 
     pet_1 = Pet.create(image: "image.jpeg", name: "Kunga", approximate_age: "1", sex: "male", shelter_id: shelter.id)
-    pet_2 = Pet.create(image: "image.jpeg", name: "Honey Pie", approximate_age: "11", sex: "female", shelter_id: shelter.id)
 
     application = AdoptionApplication.create(name: "Stella", address: "street", city: "City", state: "ST", zip: "34567", phone_number: "545-567-7643", description: "I'm awesome")
     application2 = AdoptionApplication.create(name: "Betsy", address: "street", city: "City", state: "ST", zip: "34567", phone_number: "545-567-7643", description: "I'm awesome as well")
@@ -100,6 +99,50 @@ RSpec.describe "applications show page" do
     visit "/adoption_applications/#{application2.id}"
 
     expect(page).to have_no_content("Approve Application")
+  end
 
+  it "can unapprove an adoption applicaton" do
+    shelter = Shelter.create(name: "Happy Puppies", address: "55 Street St", city: "Danger Mountain", state: "UT", zip: "80304")
+
+    pet_1 = Pet.create(image: "image.jpeg", name: "Kunga", approximate_age: "1", sex: "male", shelter_id: shelter.id)
+
+    application = AdoptionApplication.create(name: "Stella", address: "street", city: "City", state: "ST", zip: "34567", phone_number: "545-567-7643", description: "I'm awesome")
+
+    PetApplication.create(pet_id: pet_1.id, adoption_application_id: application.id)
+
+    visit "/adoption_applications/#{application.id}"
+
+    within ".pets-#{pet_1.id}" do
+      click_link "Approve Application"
+    end
+
+    visit "/adoption_applications/#{application.id}"
+
+    expect(page).to have_content("Unapprove Application")
+    expect(page).to have_no_content("Approve Application")
+  end
+
+  xit "can update pet adoption status with unapprove button" do
+    shelter = Shelter.create(name: "Happy Puppies", address: "55 Street St", city: "Danger Mountain", state: "UT", zip: "80304")
+
+    pet_1 = Pet.create(image: "image.jpeg", name: "Kunga", approximate_age: "1", sex: "male", shelter_id: shelter.id)
+
+    application = AdoptionApplication.create(name: "Stella", address: "street", city: "City", state: "ST", zip: "34567", phone_number: "545-567-7643", description: "I'm awesome")
+
+    PetApplication.create(pet_id: pet_1.id, adoption_application_id: application.id)
+
+    visit "/adoption_applications/#{application.id}"
+    click_link "Approve Application"
+
+    visit "/adoption_applications/#{application.id}"
+    click_link "Unapprove Application"
+
+    expect(current_path).to eq("/adoption_applications/#{application.id}")
+    expect(page).to have_content("Approve Application")
+
+    visit "/pets/#{pet_1.id}"
+    expect(page).to have_content("adoptable")
+    expect(page).to have_no_content("adoption pending")
+    expect(page).to have_no_content("This pet is on hold for Stella.")
   end
 end


### PR DESCRIPTION
Completed Pet Applications user stories. 

Added a column to the PetApplications joins table to track approval status and used this to determine how to make adjustments on various pages based on whether pets were still available for adoption, applications were approved, etc. 

Applications can now be approved and unapproved. If approved, the pet is now marked as "adoption pending" and a button appears to "unapproved application". If an application is approved for one pet, it is still possible to approve for a different pet since they are separate objects in the PetApplications joins table. 